### PR TITLE
Check that a credential request has at least one attribute

### DIFF
--- a/src/main/java/org/irmacard/api/common/CredentialRequest.java
+++ b/src/main/java/org/irmacard/api/common/CredentialRequest.java
@@ -116,6 +116,10 @@ public class CredentialRequest implements Serializable {
 		if (cd == null)
 			return false;
 
+		// No attributes in this credential request.
+		if (attributes.size() == 0)
+			return false;
+
 		List<String> storeAttributes = cd.getAttributeNames();
 
 		// Are all attributes in the CredentailDescription?


### PR DESCRIPTION
Now that optional attributes are supported, a client might try to issue a credential with no attribute at all (if all attributes are optional).