### PR TITLE
Include timestamps in signature proof responses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 
-version = '1.1.0'
+version = '1.1.1'
 group = 'org.irmacard.api'
 
 targetCompatibility = '1.7'

--- a/src/main/java/org/irmacard/api/common/IrmaSignedMessage.java
+++ b/src/main/java/org/irmacard/api/common/IrmaSignedMessage.java
@@ -60,6 +60,7 @@ public class IrmaSignedMessage {
 		if (request == null) {
 			request = new SignatureProofRequest(nonce, context,
 					new AttributeDisjunctionList(), message);
+			request.setTimestamp(getTimestamp());
 		}
 
 		SignatureProofResult result = request.verify(signature, validityDate, allowExpired);

--- a/src/main/java/org/irmacard/api/common/IrmaSignedMessage.java
+++ b/src/main/java/org/irmacard/api/common/IrmaSignedMessage.java
@@ -23,11 +23,12 @@ public class IrmaSignedMessage {
 
 	private transient Map<AttributeIdentifier, String> attributes;
 
-	public IrmaSignedMessage(ProofList proofs, BigInteger nonce, BigInteger context, String message) {
+	public IrmaSignedMessage(ProofList proofs, BigInteger nonce, BigInteger context, String message, Timestamp timestamp) {
 		this.signature = proofs;
 		this.nonce = nonce;
 		this.context = context;
 		this.message = message;
+		this.timestamp = timestamp;
 	}
 
 	public Map<AttributeIdentifier, String> getAttributes() throws IllegalArgumentException {

--- a/src/main/java/org/irmacard/api/common/signatures/SignatureProofResult.java
+++ b/src/main/java/org/irmacard/api/common/signatures/SignatureProofResult.java
@@ -2,6 +2,7 @@ package org.irmacard.api.common.signatures;
 
 import org.irmacard.api.common.IrmaSignedMessage;
 import org.irmacard.api.common.disclosure.DisclosureProofResult;
+import org.irmacard.api.common.timestamp.Timestamp;
 import org.irmacard.credentials.idemix.proofs.ProofList;
 
 import java.math.BigInteger;
@@ -17,13 +18,13 @@ public class SignatureProofResult extends DisclosureProofResult {
     }
 
     public SignatureProofResult(ProofList proofs, String message,
-                                BigInteger nonce, BigInteger context) {
+                                BigInteger nonce, BigInteger context, Timestamp timestamp) {
         setStatus(Status.VALID); // Note: we don't check the validity here!
-        this.signature = new IrmaSignedMessage(proofs, nonce, context, message);
+        this.signature = new IrmaSignedMessage(proofs, nonce, context, message, timestamp);
     }
 
     public SignatureProofResult(ProofList proofs, SignatureProofRequest request) {
-        this(proofs, request.getMessage(), request.getSignatureNonce(), request.getContext());
+        this(proofs, request.getMessage(), request.getSignatureNonce(), request.getContext(), request.getTimestamp());
     }
 
     @Override


### PR DESCRIPTION
This allows irmago / irma_signature_app to verify signatures coming from
the api server (so it'll restore compatibility between the two signature implementations again).

Note that this PR doesn't fix the TODOs regarding verification of timestamps in IRMA Api Server